### PR TITLE
fix: normalize escape and numpad enter

### DIFF
--- a/packages/cli/src/ui/hooks/useKeypress.test.ts
+++ b/packages/cli/src/ui/hooks/useKeypress.test.ts
@@ -10,6 +10,8 @@ import { useStdin } from 'ink';
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 
+const ESC = String.fromCharCode(27);
+
 // Mock the 'ink' module to control stdin
 vi.mock('ink', async (importOriginal) => {
   const original = await importOriginal<typeof import('ink')>();
@@ -170,6 +172,22 @@ describe('useKeypress', () => {
     act(() => stdin.pressKey(key));
     expect(onKeypress).toHaveBeenCalledWith(
       expect.objectContaining({ ...key, meta: true, paste: false }),
+    );
+  });
+
+  it('should normalize escape key when name is missing', () => {
+    renderHook(() => useKeypress(onKeypress, { isActive: true }));
+    act(() => stdin.pressKey({ sequence: ESC }));
+    expect(onKeypress).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'escape', sequence: ESC }),
+    );
+  });
+
+  it('should normalize numpad enter to return', () => {
+    renderHook(() => useKeypress(onKeypress, { isActive: true }));
+    act(() => stdin.pressKey({ sequence: `${ESC}OM` }));
+    expect(onKeypress).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'return', sequence: '\r', shift: false }),
     );
   });
 

--- a/packages/cli/src/ui/hooks/useKeypress.ts
+++ b/packages/cli/src/ui/hooks/useKeypress.ts
@@ -21,6 +21,7 @@ import {
 import { FOCUS_IN, FOCUS_OUT } from './useFocus.js';
 
 const ESC = '\u001B';
+const NUMPAD_ENTER = `${ESC}OM`;
 export const PASTE_MODE_PREFIX = `${ESC}[200~`;
 export const PASTE_MODE_SUFFIX = `${ESC}[201~`;
 
@@ -307,6 +308,16 @@ export function useKeypress(
         if (isPaste) {
           pasteBuffer = Buffer.concat([pasteBuffer, Buffer.from(key.sequence)]);
         } else {
+          // Normalize certain key sequences that readline doesn't map
+          if (!key.name && key.sequence === ESC) {
+            key.name = 'escape';
+          } else if (key.sequence === NUMPAD_ENTER) {
+            key.name = 'return';
+            key.sequence = '\r';
+            key.shift = false;
+          } else if (key.name === 'enter') {
+            key.name = 'return';
+          }
           // Handle special keys
           if (key.name === 'return' && key.sequence === `${ESC}\r`) {
             key.meta = true;


### PR DESCRIPTION
## Summary
- normalize raw escape characters and numpad enter sequences in keypress handling
- add tests covering escape and numpad enter normalization

## Testing
- `npm test` (fails: Failed to resolve entry for package "@google/gemini-cli-core")
- `npm run build` (fails: Command failed: tsc --build)


------
https://chatgpt.com/codex/tasks/task_e_689ec00f20c0832c9f42bdc3d80c699c